### PR TITLE
Add unit test for header ID of a WAD and extract header ID

### DIFF
--- a/DoomGame/WADReader.cpp
+++ b/DoomGame/WADReader.cpp
@@ -7,22 +7,34 @@ WADReader::~WADReader() {};
 // https://coniferproductions.com/posts/2022/10/25/reading-binary-files-cpp/
 std::vector<std::byte> WADReader::readFileData(const std::string& name)
 {
-    std::filesystem::path inputFilePath{ name };
+	std::filesystem::path inputFilePath{ name };
 
-    if (!std::filesystem::exists(inputFilePath)) 
-    {
-        throw std::runtime_error("File does not exist: " + name);
-    }
+	if (!std::filesystem::exists(inputFilePath))
+	{
+		throw std::runtime_error("File does not exist: " + name);
+	}
 
-    auto length = std::filesystem::file_size(inputFilePath);
-    if (length == 0) 
-    {
-        return {}; // empty vector
-    }
-    std::vector<std::byte> buffer(length);
-    std::ifstream inputFile(name, std::ios_base::binary);
+	auto length = std::filesystem::file_size(inputFilePath);
+	if (length == 0)
+	{
+		return {}; // empty vector
+	}
+	std::vector<std::byte> buffer(length);
+	std::ifstream inputFile(name, std::ios_base::binary);
 
-    inputFile.read(reinterpret_cast<char*>(buffer.data()), length);
-    inputFile.close();
-    return buffer;
+	inputFile.read(reinterpret_cast<char*>(buffer.data()), length);
+
+	inputFile.close();
+	return buffer;
+}
+
+std::string WADReader::extractID(std::vector<std::byte>& buffer)
+{
+	char id[5] = {};
+	for (int i = 0; i < 4; i++)
+	{
+		id[i] = (char)buffer.at(i);
+	}
+	id[4] = '\0';
+	return std::string(id);
 }

--- a/DoomGame/WADReader.h
+++ b/DoomGame/WADReader.h
@@ -10,6 +10,10 @@ public:
 
 	std::vector<std::byte> readFileData(const std::string& name);
 
+	std::string extractID(std::vector<std::byte>& buffer);
+
 	~WADReader();
+
+
 };
 

--- a/DoomGameTests/WADReaderTests.cpp
+++ b/DoomGameTests/WADReaderTests.cpp
@@ -2,14 +2,22 @@
 #include "../DoomGame/WADReader.h"
 #include "../DoomGame/WADReader.cpp"
 
-class WADReaderTests : public ::testing::Test {
+class WADReaderTests : public ::testing::Test 
+{
 protected:
 	WADReader wadReader;
 };
 
 
 
-static TEST_F(WADReaderTests, HandleNonExistentFile) {
+static TEST_F(WADReaderTests, HandleNonExistentFile) 
+{
 	std::string path = "./FAKE.WAD";
 	EXPECT_THROW(wadReader.readFileData(path), std::runtime_error);
+}
+
+static TEST_F(WADReaderTests, HandleHeaderID) 
+{
+	auto buffer = wadReader.readFileData("./DOOM.WAD");
+	ASSERT_EQ(wadReader.extractID(buffer), "IWAD");
 }


### PR DESCRIPTION
## Add unit test for header ID of a WAD and extract header ID

### Purpose

This pull request adds a unit test for a WAD's header ID and a method that extracts the header ID.

See:
https://doom.fandom.com/wiki/WAD#Header

### Changes Made
- Add a unit test to extract the header ID expecting IWAD as the ID
- Created a method extractID that reads the first 4 bytes* of the buffer

### Testing Done
- Wrote the unit test first and had it fail, then wrote the functionality to pass the test. Once the test passes, then refactor the code. Verify that the test still passes.

### Next Steps
- Write the test for the numlumps of the WAD and then implement the functionality to read the numlumps and pass the test. Once the test passes, refactor the code written. Then verify the test still passes.
---
*I needed clarification on whether it was bits instead of bytes, but upon further investigating the data's actual nature, I found that it is indeed 4 bytes. Each byte represents a decimal number, and with the ASCII table, they correspond to a character. It wouldn't make sense to be bits because a bit can only be 0 or 1, and these 4-byte values are decimal numbers. According to the wiki page, it claims it is 4 bytes.