### PR TITLE
Add a header file DataTypes to hold structs, update extractID, update the unit test, and call extractID in main

### DIFF
--- a/DoomGame/DataTypes.h
+++ b/DoomGame/DataTypes.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <cstdint>
+
+struct Header
+{
+	char WADType[5];
+	uint32_t directoryCount;
+	uint32_t directoryOffset;
+};

--- a/DoomGame/DoomGame.vcxproj
+++ b/DoomGame/DoomGame.vcxproj
@@ -132,6 +132,7 @@
     <ClCompile Include="WADReader.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="DataTypes.h" />
     <ClInclude Include="WADReader.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/DoomGame/DoomGame.vcxproj.filters
+++ b/DoomGame/DoomGame.vcxproj.filters
@@ -26,5 +26,8 @@
     <ClInclude Include="WADReader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DataTypes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/DoomGame/Main.cpp
+++ b/DoomGame/Main.cpp
@@ -8,8 +8,11 @@ int main()
 {
 	try
 	{
+		Header header;
+
 		WADReader wadReader;
-		wadReader.readFileData("./DOOM.WAD");
+		auto buffer = wadReader.readFileData("./DOOM.WAD");
+		wadReader.extractID(buffer,header);
 		return 0;
 	}
 	catch (const std::runtime_error& e)

--- a/DoomGame/WADReader.cpp
+++ b/DoomGame/WADReader.cpp
@@ -28,13 +28,12 @@ std::vector<std::byte> WADReader::readFileData(const std::string& name)
 	return buffer;
 }
 
-std::string WADReader::extractID(std::vector<std::byte>& buffer)
+void WADReader::extractID(std::vector<std::byte>& buffer,Header &header)
 {
-	char id[5] = {};
 	for (int i = 0; i < 4; i++)
 	{
-		id[i] = (char)buffer.at(i);
+		header.WADType[i] = (char)buffer.at(i);
 	}
-	id[4] = '\0';
-	return std::string(id);
+
+	header.WADType[4] = '\0';
 }

--- a/DoomGame/WADReader.h
+++ b/DoomGame/WADReader.h
@@ -1,8 +1,10 @@
 #pragma once
+#include <iostream>
 #include <filesystem>
 #include <vector>
 #include <fstream> 
 #include <cstddef>
+#include "DataTypes.h"
 class WADReader
 {
 public:
@@ -10,7 +12,7 @@ public:
 
 	std::vector<std::byte> readFileData(const std::string& name);
 
-	std::string extractID(std::vector<std::byte>& buffer);
+	void extractID(std::vector<std::byte>& buffer, Header &header);
 
 	~WADReader();
 

--- a/DoomGameTests/WADReaderTests.cpp
+++ b/DoomGameTests/WADReaderTests.cpp
@@ -1,11 +1,13 @@
 #include "pch.h"
 #include "../DoomGame/WADReader.h"
 #include "../DoomGame/WADReader.cpp"
+#include "../DoomGame/DataTypes.h"
 
 class WADReaderTests : public ::testing::Test 
 {
 protected:
 	WADReader wadReader;
+	Header header;
 };
 
 
@@ -19,5 +21,7 @@ static TEST_F(WADReaderTests, HandleNonExistentFile)
 static TEST_F(WADReaderTests, HandleHeaderID) 
 {
 	auto buffer = wadReader.readFileData("./DOOM.WAD");
-	ASSERT_EQ(wadReader.extractID(buffer), "IWAD");
+	Header header;
+	wadReader.extractID(buffer, header);
+	ASSERT_EQ(std::string(header.WADType), "IWAD");
 }


### PR DESCRIPTION
## Purpose

This pull request adds a new header file that will hold structs representing specific data from the WAD file and updates methods to support the header struct. 

### Changes Made

- The struct Header represents the data of the header in the WAD to have the data in one location
- extractID was updated to support the header struct
- HandleHeaderID was updated to support the header struct

### Testing Done
- Updated the unit test HandleHeaderID to support the header struct and verified that the test still passed. Verifying the correct ID was read from the WAD.

### Next Steps
- Add methods to read 2 bytes and to read 4 bytes, then implement reading of the number of lumps defined in the header and the integer that holds a pointer to the location of the directory. 