### PR TITLE
Read bytes

### DIFF
--- a/DoomGame/WADReader.cpp
+++ b/DoomGame/WADReader.cpp
@@ -28,7 +28,7 @@ std::vector<std::byte> WADReader::readFileData(const std::string& name)
 	return buffer;
 }
 
-void WADReader::extractID(std::vector<std::byte>& buffer,Header &header)
+void WADReader::extractID(std::vector<std::byte>& buffer, Header& header)
 {
 	for (int i = 0; i < 4; i++)
 	{
@@ -36,4 +36,26 @@ void WADReader::extractID(std::vector<std::byte>& buffer,Header &header)
 	}
 
 	header.WADType[4] = '\0';
+}
+
+uint16_t WADReader::read2Bytes(std::vector<std::byte>& buffer, int offset)
+{
+	if (offset < 0 || buffer.size() < offset + sizeof(uint16_t))
+	{
+		throw std::runtime_error("Buffer overflow prevented. Buffer size: " + std::to_string(buffer.size()) + ", Required size from offset: " + std::to_string(offset + sizeof(uint16_t)));
+	}
+	uint16_t value;
+	std::memcpy(&value, buffer.data() + offset, sizeof(uint16_t));
+	return value;
+}
+
+uint32_t WADReader::read4Bytes(std::vector<std::byte>& buffer, int offset)
+{
+	if (offset < 0 || buffer.size() < offset + sizeof(uint32_t))
+	{
+		throw std::runtime_error("Buffer overflow prevented. Buffer size: " + std::to_string(buffer.size()) + ", Required size from offset: " + std::to_string(offset + sizeof(uint32_t)));
+	}
+	uint32_t value;
+	std::memcpy(&value, buffer.data() + offset, sizeof(uint32_t));
+	return value;
 }

--- a/DoomGame/WADReader.h
+++ b/DoomGame/WADReader.h
@@ -12,7 +12,12 @@ public:
 
 	std::vector<std::byte> readFileData(const std::string& name);
 
-	void extractID(std::vector<std::byte>& buffer, Header &header);
+	void extractID(std::vector<std::byte>& buffer, Header& header);
+
+
+	uint16_t read2Bytes(std::vector<std::byte>& buffer, int offset);
+
+	uint32_t read4Bytes(std::vector<std::byte>& buffer, int offset);
 
 	~WADReader();
 

--- a/DoomGameTests/WADReaderTests.cpp
+++ b/DoomGameTests/WADReaderTests.cpp
@@ -3,25 +3,86 @@
 #include "../DoomGame/WADReader.cpp"
 #include "../DoomGame/DataTypes.h"
 
-class WADReaderTests : public ::testing::Test 
+class WADReaderTests : public ::testing::Test
 {
 protected:
 	WADReader wadReader;
 	Header header;
 };
 
-
-
-static TEST_F(WADReaderTests, HandleNonExistentFile) 
+static TEST_F(WADReaderTests, HandleNonExistentFile)
 {
 	std::string path = "./FAKE.WAD";
 	EXPECT_THROW(wadReader.readFileData(path), std::runtime_error);
 }
 
-static TEST_F(WADReaderTests, HandleHeaderID) 
+static TEST_F(WADReaderTests, HandleHeaderID)
 {
 	auto buffer = wadReader.readFileData("./DOOM.WAD");
 	Header header;
 	wadReader.extractID(buffer, header);
 	ASSERT_EQ(std::string(header.WADType), "IWAD");
+}
+
+static TEST_F(WADReaderTests, HandleRead2Bytes)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}, std::byte{0x05}, std::byte{0x06} };
+	// Expecting 513 because 0x0201 in little-endian is 0x01 at the LSB and 0x02 at the MSB and is the decimal representation
+	ASSERT_EQ(wadReader.read2Bytes(buffer, 0), 513);
+}
+
+static TEST_F(WADReaderTests, HandleReadOutOfBounds2Bytes)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01} };
+	EXPECT_THROW(wadReader.read2Bytes(buffer, 0), std::runtime_error);
+}
+
+static TEST_F(WADReaderTests, HandleOffsetOutOfBounds2Bytes)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}, std::byte{0x05}, std::byte{0x06} };
+	EXPECT_THROW(wadReader.read2Bytes(buffer, -1), std::runtime_error);
+}
+
+static TEST_F(WADReaderTests, HandleOffsetOutOfBoundsGreater2Bytes)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02}, std::byte{0x03} };
+	EXPECT_THROW(wadReader.read2Bytes(buffer, 4), std::runtime_error);
+}
+
+static TEST_F(WADReaderTests, HandleOutOfBoundsEqual2Bytes)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02} };
+	ASSERT_EQ(wadReader.read2Bytes(buffer, 0), 513);
+}
+
+
+static TEST_F(WADReaderTests, HandleRead4Bytes)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}, std::byte{0x05}, std::byte{0x06} };
+	// Expecting 67305985 because 0x04030201 in little-endian is the decimal representation
+	ASSERT_EQ(wadReader.read4Bytes(buffer, 0), 67305985);
+}
+
+static TEST_F(WADReaderTests, HandleReadOutOfBounds)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02} };
+	EXPECT_THROW(wadReader.read4Bytes(buffer, 0), std::runtime_error);
+}
+
+static TEST_F(WADReaderTests, HandleOffsetOutOfBounds)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}, std::byte{0x05}, std::byte{0x06} };
+	EXPECT_THROW(wadReader.read4Bytes(buffer, -1), std::runtime_error);
+}
+
+static TEST_F(WADReaderTests, HandleOffsetOutOfBoundsGreater)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}, std::byte{0x05}, std::byte{0x06} };
+	EXPECT_THROW(wadReader.read4Bytes(buffer, 7), std::runtime_error);
+}
+
+static TEST_F(WADReaderTests, HandleOutOfBoundsEqual)
+{
+	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04} };
+	ASSERT_EQ(wadReader.read4Bytes(buffer, 0), 67305985);
 }


### PR DESCRIPTION
## Purpose

This pull request adds methods to read 2 and 4 bytes and unit tests to verify.


### Changes Made

- read2Bytes method, out-of-bounds check
- read4Bytes method, out-of-bounds check

### Testing Done
- Wrote tests to handle out-of-bounds conditions for reading 2 and 4 bytes. 
- Tested for if a buffer is less than the required size.
- Tested for if the offset is trying to access the buffer at a negative value.
- Tested to see if the offset is greater than the size of the buffer.
- Tested for if the buffer is exactly 2 or 4 bytes.

### Next Steps
- Add more test cases for reading bytes if needed.
- Utilize the read2Bytes and read4Bytes methods to read further data from the WAD.