### PR TITLE
Extract total number of lumps from the WAD

### DIFF
--- a/DoomGame/DataTypes.h
+++ b/DoomGame/DataTypes.h
@@ -3,7 +3,7 @@
 
 struct Header
 {
-	char WADType[5];
-	uint32_t directoryCount;
-	uint32_t directoryOffset;
+	char WADType[5]{};
+	uint32_t totalLumps{};
+	uint32_t directoryOffset{};
 };

--- a/DoomGame/Main.cpp
+++ b/DoomGame/Main.cpp
@@ -12,7 +12,8 @@ int main()
 
 		WADReader wadReader;
 		auto buffer = wadReader.readFileData("./DOOM.WAD");
-		wadReader.extractID(buffer,header);
+		wadReader.extractID(buffer, header);
+		wadReader.extractTotalLumps(buffer, header, 4);
 		return 0;
 	}
 	catch (const std::runtime_error& e)

--- a/DoomGame/WADReader.cpp
+++ b/DoomGame/WADReader.cpp
@@ -38,6 +38,11 @@ void WADReader::extractID(std::vector<std::byte>& buffer, Header& header)
 	header.WADType[4] = '\0';
 }
 
+void WADReader::extractTotalLumps(std::vector<std::byte>& buffer, Header& header, int offset)
+{
+	header.totalLumps = read4Bytes(buffer, offset);
+}
+
 uint16_t WADReader::read2Bytes(std::vector<std::byte>& buffer, int offset)
 {
 	if (offset < 0 || buffer.size() < offset + sizeof(uint16_t))

--- a/DoomGame/WADReader.h
+++ b/DoomGame/WADReader.h
@@ -14,6 +14,7 @@ public:
 
 	void extractID(std::vector<std::byte>& buffer, Header& header);
 
+	void extractTotalLumps(std::vector<std::byte>& buffer, Header& header, int offset);
 
 	uint16_t read2Bytes(std::vector<std::byte>& buffer, int offset);
 

--- a/DoomGameTests/WADReaderTests.cpp
+++ b/DoomGameTests/WADReaderTests.cpp
@@ -7,7 +7,7 @@ class WADReaderTests : public ::testing::Test
 {
 protected:
 	WADReader wadReader;
-	Header header;
+	Header header{};
 };
 
 static TEST_F(WADReaderTests, HandleNonExistentFile)
@@ -19,7 +19,6 @@ static TEST_F(WADReaderTests, HandleNonExistentFile)
 static TEST_F(WADReaderTests, HandleHeaderID)
 {
 	auto buffer = wadReader.readFileData("./DOOM.WAD");
-	Header header;
 	wadReader.extractID(buffer, header);
 	ASSERT_EQ(std::string(header.WADType), "IWAD");
 }
@@ -85,4 +84,11 @@ static TEST_F(WADReaderTests, HandleOutOfBoundsEqual)
 {
 	std::vector<std::byte> buffer = { std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04} };
 	ASSERT_EQ(wadReader.read4Bytes(buffer, 0), 67305985);
+}
+
+static TEST_F(WADReaderTests, HandleTotalLumps)
+{
+	auto buffer = wadReader.readFileData("./DOOM.WAD");
+	wadReader.extractTotalLumps(buffer, header, 4);
+	ASSERT_EQ(header.totalLumps, 2306);
 }


### PR DESCRIPTION
## Purpose

This pull request extracts the total number of lumps in a WAD file.

### Changes Made
- rename directoryCount in the header struct to be totalLumps.
- Add default member initialization to the members in the Header struct.
- List initialization for the Header object.
- Made the header a member of the WADReaderTests class.
- Extract the total number of lumps by reading four bytes from the offset.

### Testing Done
- Tested to see if the total number of lumps was the expected value.

### Next Steps
- Add more tests for checking the total number of lumps.
- Add support for PWAD files and respective tests.
- Refactor the buffer in WADReaderTests so it is not instantiated multiple times.