### PR TITLE
Refactor read header

### DIFF
--- a/DoomGame/Main.cpp
+++ b/DoomGame/Main.cpp
@@ -12,7 +12,8 @@ int main()
 
 		WADReader wadReader;
 		auto buffer = wadReader.readFileData("./DOOM.WAD");
-		wadReader.readHeader(buffer, header);
+		int offset = 0;
+		wadReader.readHeader(buffer, header, offset);
 		return 0;
 	}
 	catch (const std::runtime_error& e)

--- a/DoomGame/Main.cpp
+++ b/DoomGame/Main.cpp
@@ -12,8 +12,7 @@ int main()
 
 		WADReader wadReader;
 		auto buffer = wadReader.readFileData("./DOOM.WAD");
-		wadReader.extractID(buffer, header);
-		wadReader.extractTotalLumps(buffer, header, 4);
+		wadReader.readHeader(buffer, header);
 		return 0;
 	}
 	catch (const std::runtime_error& e)

--- a/DoomGame/WADReader.cpp
+++ b/DoomGame/WADReader.cpp
@@ -28,13 +28,13 @@ std::vector<std::byte> WADReader::readFileData(const std::string& name)
 	return buffer;
 }
 
-void WADReader::readHeader(std::vector<std::byte>& buffer, Header& header)
+void WADReader::readHeader(std::vector<std::byte>& buffer, Header& header, int& offset)
 {
-	extractID(buffer, header);
-	extractTotalLumps(buffer, header, 4);
+	extractID(buffer, header, offset);
+	extractTotalLumps(buffer, header, offset);
 }
 
-void WADReader::extractID(std::vector<std::byte>& buffer, Header& header)
+void WADReader::extractID(std::vector<std::byte>& buffer, Header& header, int& offset)
 {
 	for (int i = 0; i < 4; i++)
 	{
@@ -42,11 +42,13 @@ void WADReader::extractID(std::vector<std::byte>& buffer, Header& header)
 	}
 
 	header.WADType[4] = '\0';
+	offset += 4;
 }
 
-void WADReader::extractTotalLumps(std::vector<std::byte>& buffer, Header& header, int offset)
+void WADReader::extractTotalLumps(std::vector<std::byte>& buffer, Header& header, int& offset)
 {
 	header.totalLumps = read4Bytes(buffer, offset);
+	offset += 4;
 }
 
 uint16_t WADReader::read2Bytes(std::vector<std::byte>& buffer, int offset)

--- a/DoomGame/WADReader.cpp
+++ b/DoomGame/WADReader.cpp
@@ -28,6 +28,12 @@ std::vector<std::byte> WADReader::readFileData(const std::string& name)
 	return buffer;
 }
 
+void WADReader::readHeader(std::vector<std::byte>& buffer, Header& header)
+{
+	extractID(buffer, header);
+	extractTotalLumps(buffer, header, 4);
+}
+
 void WADReader::extractID(std::vector<std::byte>& buffer, Header& header)
 {
 	for (int i = 0; i < 4; i++)

--- a/DoomGame/WADReader.h
+++ b/DoomGame/WADReader.h
@@ -12,11 +12,11 @@ public:
 
 	std::vector<std::byte> readFileData(const std::string& name);
 
-	void readHeader(std::vector<std::byte>& buffer, Header& header);
+	void readHeader(std::vector<std::byte>& buffer, Header& header, int& offset);
 
-	void extractID(std::vector<std::byte>& buffer, Header& header);
+	void extractID(std::vector<std::byte>& buffer, Header& header, int& offset);
 
-	void extractTotalLumps(std::vector<std::byte>& buffer, Header& header, int offset);
+	void extractTotalLumps(std::vector<std::byte>& buffer, Header& header, int& offset);
 
 	uint16_t read2Bytes(std::vector<std::byte>& buffer, int offset);
 

--- a/DoomGame/WADReader.h
+++ b/DoomGame/WADReader.h
@@ -12,6 +12,8 @@ public:
 
 	std::vector<std::byte> readFileData(const std::string& name);
 
+	void readHeader(std::vector<std::byte>& buffer, Header& header);
+
 	void extractID(std::vector<std::byte>& buffer, Header& header);
 
 	void extractTotalLumps(std::vector<std::byte>& buffer, Header& header, int offset);

--- a/DoomGameTests/WADReaderTests.cpp
+++ b/DoomGameTests/WADReaderTests.cpp
@@ -8,6 +8,7 @@ class WADReaderTests : public ::testing::Test
 protected:
 	WADReader wadReader;
 	Header header{};
+	int offset = 0;
 };
 
 static TEST_F(WADReaderTests, HandleNonExistentFile)
@@ -19,7 +20,7 @@ static TEST_F(WADReaderTests, HandleNonExistentFile)
 static TEST_F(WADReaderTests, HandleHeaderID)
 {
 	auto buffer = wadReader.readFileData("./DOOM.WAD");
-	wadReader.extractID(buffer, header);
+	wadReader.extractID(buffer, header, offset);
 	ASSERT_EQ(std::string(header.WADType), "IWAD");
 }
 
@@ -89,6 +90,7 @@ static TEST_F(WADReaderTests, HandleOutOfBoundsEqual)
 static TEST_F(WADReaderTests, HandleTotalLumps)
 {
 	auto buffer = wadReader.readFileData("./DOOM.WAD");
-	wadReader.extractTotalLumps(buffer, header, 4);
+	offset += 4;
+	wadReader.extractTotalLumps(buffer, header, offset);
 	ASSERT_EQ(header.totalLumps, 2306);
 }


### PR DESCRIPTION
## Purpose
This pull request refactors the reading of the header of a WAD.
### Changes Made
- Refactor extractID and extractTotalLumps into a readHeader method.
- Refactor readHeader to use an incrementing offset.
- Update extractID and extractTotalLumps to use and increment offset.
- Adjust WADReaderTests to reflect offset changes.
- Add an offset variable to the main function and update the readHeader call.